### PR TITLE
deactivated-azure-terraform-ci.yaml

### DIFF
--- a/.github/workflows/azure-terraform-ci.yaml
+++ b/.github/workflows/azure-terraform-ci.yaml
@@ -2,7 +2,7 @@ name: "Terraform Deploy"
 on:
   push:
     branches:
-      - dev
+      - main
 
 
 jobs:


### PR DESCRIPTION
Deixei para a pipeline rodar apenas quando rodar alguma atualização para a main, a infra sobe imediatamente quando der o merge da dev para a Main, então usem com moderação e acompanhem no painel da azure. Quem não tiver acesso ainda, me avisa para inserir no Azure AD.